### PR TITLE
Build Static Linux Binary with CGO_ENABLED=0 for support older Linux systems

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
         with:
-          go-version: '1.24'
+          go-version: '1.18'
 
       - name: Build Linux Binary
         run: GOOS=linux GOARCH=amd64 go build -o cp-tf-inspect .

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,10 +27,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
         with:
-          go-version: '1.18'
+          go-version: '1.24'
 
       - name: Build Linux Binary
-        run: GOOS=linux GOARCH=amd64 go build -o cp-tf-inspect .
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o cp-tf-inspect .
 
       - name: Run Unit Tests
         run: go test ./cmd/...


### PR DESCRIPTION
This PR updates the release build process for cp-tf-inspect to use CGO_ENABLED=0 when building the Linux binary.

Issues Fixed:
- Runtime errors on older and slim Linux distributions where glibc 2.32+ is not available (GLIBC_2.34' not found etc). - (This issue has been found in this CLI after go - 1.24.x update)